### PR TITLE
Revert "fix: add common constraint of redis<4"

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -20,6 +20,3 @@ Django<4.0
 elasticsearch<7.14.0
 
 setuptools<60
-
-# redis 4 client doesn't play nicely with redis 3 server
-redis<4


### PR DESCRIPTION
Empirical data has led us to rule out redis-py version 4 as the cause of some redis server instability.
We believe the instability is related to the lack of connection pooling in edx-platform and ecommerce.
See: https://openedx.atlassian.net/wiki/spaces/ENG/pages/3316580400/Redis+outage+-+technical+investigation#The-LMS-and-studio-celery-config-does-not-use-celery-connection-pooling

This reverts commit 210c2b2cdb29e0c65b1df0bb254defd321f4d9f9.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [x] Changelog record added (if needed)
- [x] Documentation updated (not only docstrings) (if needed)
- [x] Commits are squashed
