### PR TITLE
fix: fix import issues with pylint==2.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [pylint, pylint24]
+        toxenv: [py38, pylint, pylint212]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+5.2.2 - 2022-03-25
+~~~~~~~~~~~~~~~~~~
+
+* fixed import path of a pylint protected function to make
+  edx-lint compatible with `pylint==2.13.0`.
+* Updated testenvs in both tox and CI
+
 5.2.1 - 2021-10-26
 ~~~~~~~~~~~~~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: ## display this help message
 	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | sort | awk -F ':.*?## ' 'NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 test: ## run all the tests
-	tox -e py38-pylint24,coverage
+	tox
 
 pylint: ## check our own code with pylint
 	tox -e pylint

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-__version__ = "5.2.1"
+__version__ = "5.2.2"

--- a/edx_lint/pylint/super_check.py
+++ b/edx_lint/pylint/super_check.py
@@ -2,7 +2,10 @@
 
 import astroid
 from pylint.checkers import BaseChecker, utils
-from pylint.checkers.classes import _ancestors_to_call
+try:
+    from pylint.checkers.classes import _ancestors_to_call
+except ImportError:
+    from pylint.checkers.classes.class_checker import _ancestors_to_call
 from pylint.interfaces import IAstroidChecker
 
 from .common import BASE_ID, check_visitors, usable_class_name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.9.3
+astroid==2.11.1
     # via
     #   pylint
     #   pylint-celery
@@ -19,21 +19,23 @@ code-annotations==1.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+dill==0.3.4
+    # via pylint
 isort==5.10.1
     # via pylint
-jinja2==3.0.3
+jinja2==3.1.0
     # via code-annotations
 lazy-object-proxy==1.7.1
     # via astroid
 markupsafe==2.1.1
     # via jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 pbr==5.8.1
     # via stevedore
 platformdirs==2.5.1
     # via pylint
-pylint==2.12.2
+pylint==2.13.0
     # via
     #   -r requirements/base.in
     #   pylint-celery
@@ -57,13 +59,13 @@ stevedore==3.5.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-toml==0.10.2
+tomli==2.0.1
     # via pylint
 typing-extensions==4.1.1
     # via
     #   astroid
     #   pylint
-wrapt==1.13.3
+wrapt==1.14.0
     # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.9.3
+astroid==2.11.1
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -20,6 +20,10 @@ code-annotations==1.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+dill==0.3.4
+    # via
+    #   -r requirements/base.txt
+    #   pylint
 distlib==0.3.4
     # via virtualenv
 filelock==3.6.0
@@ -30,7 +34,7 @@ isort==5.10.1
     # via
     #   -r requirements/base.txt
     #   pylint
-jinja2==3.0.3
+jinja2==3.1.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -42,7 +46,7 @@ markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -61,7 +65,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pylint==2.12.2
+pylint==2.13.0
     # via
     #   -r requirements/base.txt
     #   pylint-celery
@@ -100,10 +104,11 @@ text-unidecode==1.3
     #   -r requirements/base.txt
     #   python-slugify
 toml==0.10.2
+    # via tox
+tomli==2.0.1
     # via
     #   -r requirements/base.txt
     #   pylint
-    #   tox
 tox==3.24.5
     # via
     #   -r requirements/dev.in
@@ -117,7 +122,7 @@ typing-extensions==4.1.1
     #   pylint
 virtualenv==20.13.4
     # via tox
-wrapt==1.13.3
+wrapt==1.14.0
     # via
     #   -r requirements/base.txt
     #   astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.5.0
     # via django
-astroid==2.9.3
+astroid==2.11.1
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -26,6 +26,10 @@ code-annotations==1.3.0
     #   -r requirements/dev.txt
 coverage==6.3.2
     # via -r requirements/test.in
+dill==0.3.4
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
 distlib==0.3.4
     # via
     #   -r requirements/dev.txt
@@ -45,7 +49,7 @@ isort==5.10.1
     # via
     #   -r requirements/dev.txt
     #   pylint
-jinja2==3.0.3
+jinja2==3.1.0
     # via
     #   -r requirements/dev.txt
     #   code-annotations
@@ -57,7 +61,7 @@ markupsafe==2.1.1
     # via
     #   -r requirements/dev.txt
     #   jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -85,7 +89,7 @@ py==1.11.0
     #   -r requirements/dev.txt
     #   pytest
     #   tox
-pylint==2.12.2
+pylint==2.13.0
     # via
     #   -r requirements/dev.txt
     #   pylint-celery
@@ -134,10 +138,12 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/dev.txt
-    #   pylint
     #   tox
 tomli==2.0.1
-    # via pytest
+    # via
+    #   -r requirements/dev.txt
+    #   pylint
+    #   pytest
 tox==3.24.5
     # via
     #   -r requirements/dev.txt
@@ -153,7 +159,7 @@ virtualenv==20.13.4
     # via
     #   -r requirements/dev.txt
     #   tox
-wrapt==1.13.3
+wrapt==1.14.0
     # via
     #   -r requirements/dev.txt
     #   astroid

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,33 @@
 [tox]
-envlist = py38-pylint{24}, coverage, pylint
+envlist = py38, coverage, pylint, pylint212
 
 [testenv]
 deps =
     -r{toxinidir}/requirements/test.txt
-
 commands =
-    # edx_lint itself pins the pylint version, so we have to re-install pylint
-    # to test on different versions.
-    pylint24: pip install -q pylint>=2.4,<2.5
-    pylint --version
     coverage run -p -m pytest {posargs:}
 
 [testenv:coverage]
-envdir = {toxworkdir}/py38-pylint24
+deps =
+    -r{toxinidir}/requirements/test.txt
 commands =
     coverage combine
     coverage report -m
     coverage html
 
 [testenv:pylint]
-envdir = {toxworkdir}/py38-pylint24
-passenv = PYLINT*
-commands = pylint edx_lint test setup.py
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    pylint edx_lint test setup.py
+
+[testenv:pylint212]
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    pip install -q pylint<2.13.0
+    pylint --version
+    pylint edx_lint test setup.py
 
 [pytest]
 addopts = -rfe


### PR DESCRIPTION
### Description
- Updated the import path of a protected pylint function `_ancestors_to_call()` to fix the breaking issue with `pylint==2.13.0`. 

### Detail
- `pylint==2.13.0` refactored the `pylint.checkers.classes` module and moved the `_ancestors_to_call()` function from `pylint.checkers.classes.__init__.py` to `pylint.checkers.classes.checkers_classes.py`. See [PR](https://github.com/PyCQA/pylint/pull/5497) for details. 
- This caused the error with new `pylint==2.13.0` version across all edx repos in running `python requirements upgrade` job. 

### TODO
- For now, only the module path is being updated but this piece of code should be removed/updated to remove this dependency on an internal function altogether.