### PR TITLE
BOM-3400: Pin pip<22.1 in common constraints

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -20,3 +20,7 @@ Django<4.0
 elasticsearch<7.14.0
 
 setuptools<60
+
+# pip-tools fails with latest pip==22.1 version. 
+# The failure details are in the issue https://github.com/jazzband/pip-tools/issues/1617.
+pip<22.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   pylint
     #   pylint-celery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -18,7 +18,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
 six==1.16.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -80,7 +80,7 @@ pylint-plugin-utils==0.7
     #   -r requirements/base.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
 python-slugify==6.1.2
     # via

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,4 +1,5 @@
 # Core dependencies for installing other packages
+-c constraints.txt
 
 pip
 setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,6 +9,10 @@ wheel==0.35.1
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.4
-    # via -r requirements/pip.in
+    # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in
 setuptools==50.3.2
-    # via -r requirements/pip.in
+    # via
+    #   -c requirements/../edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.5.1
     # via django
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -24,7 +24,7 @@ code-annotations==1.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
-coverage==6.3.2
+coverage==6.3.3
     # via -r requirements/test.in
 dill==0.3.4
     # via
@@ -104,7 +104,7 @@ pylint-plugin-utils==0.7
     #   -r requirements/dev.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/dev.txt
     #   packaging


### PR DESCRIPTION
**Issue:** [BOM-3400](https://openedx.atlassian.net/browse/BOM-3400)

### Description
- pip-tools fails with latest pip==22.1 version. The failure details are in the issue https://github.com/jazzband/pip-tools/issues/1617.