### PR TITLE
fix: pin django-simple-history version

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -24,3 +24,6 @@ setuptools<60
 # pip-tools fails with latest pip==22.1 version. 
 # The failure details are in the issue https://github.com/jazzband/pip-tools/issues/1617.
 pip<22.1
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.4
     # via virtualenv
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   tox
     #   virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,7 +26,7 @@ dill==0.3.4
     #   pylint
 distlib==0.3.4
     # via virtualenv
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   tox
     #   virtualenv

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -38,7 +38,7 @@ django==3.2.13
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   -r requirements/dev.txt
     #   tox


### PR DESCRIPTION
**Issue:** [BOM-xxxx](https://openedx.atlassian.net/browse/BOM-xxxx)

### Description
- `django-simple-history>3.0.0` adds indexing and causes a lot of migrations to be affected. Indexing can be skipped by providing a custom argument from settings but it still updated a lot of meta attributes and causes the migrations to be updated. 
- The version will be pinned for now and the flag will be added in the required repos in separate repos.
- Then the version will be bumped later on after investigating all the needed changes and the best method to handle migrations update.