### PR TITLE
BOM-3400: Remove pip common constraint

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -21,9 +21,5 @@ elasticsearch<7.14.0
 
 setuptools<60
 
-# pip-tools fails with latest pip==22.1 version. 
-# The failure details are in the issue https://github.com/jazzband/pip-tools/issues/1617.
-pip<22.1
-
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,7 +35,7 @@ pbr==5.9.0
     # via stevedore
 platformdirs==2.5.2
     # via pylint
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/base.in
     #   pylint-celery

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,7 +65,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/base.txt
     #   pylint-celery

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,9 +9,7 @@ wheel==0.35.1
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.2.4
-    # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
-    #   -r requirements/pip.in
+    # via -r requirements/pip.in
 setuptools==50.3.2
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -89,7 +89,7 @@ py==1.11.0
     #   -r requirements/dev.txt
     #   pytest
     #   tox
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/dev.txt
     #   pylint-celery


### PR DESCRIPTION
**Issue:** [BOM-3400](https://openedx.atlassian.net/browse/BOM-3400)

### Description
- `pip-tools==6.6.1` [resolved](https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md#661-2022-05-13) the compatibility issues with `pip>=22.1` so removed the pin from common constraints.