### PR TITLE
chore: upgrade requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage.xml
 *~
 build/
 dist/
+.DS_Store
 
 .eggs/
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,7 +35,7 @@ pbr==5.9.0
     # via stevedore
 platformdirs==2.5.2
     # via pylint
-pylint==2.14.3
+pylint==2.14.4
     # via
     #   -r requirements/base.in
     #   pylint-celery
@@ -63,7 +63,7 @@ tomli==2.0.1
     # via pylint
 tomlkit==0.11.0
     # via pylint
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -26,7 +26,7 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.25.0
+tox==3.25.1
     # via -r requirements/ci.in
-virtualenv==20.15.0
+virtualenv==20.15.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,7 +65,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pylint==2.14.3
+pylint==2.14.4
     # via
     #   -r requirements/base.txt
     #   pylint-celery
@@ -113,18 +113,18 @@ tomlkit==0.11.0
     # via
     #   -r requirements/base.txt
     #   pylint
-tox==3.25.0
+tox==3.25.1
     # via
     #   -r requirements/dev.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/base.txt
     #   astroid
     #   pylint
-virtualenv==20.15.0
+virtualenv==20.15.1
     # via tox
 wrapt==1.14.1
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
+build==0.8.0
+    # via pip-tools
 click==8.1.3
     # via pip-tools
+packaging==21.3
+    # via build
 pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.in
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via pep517
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.35.1
+wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.2.4
+pip==22.1.2
     # via -r requirements/pip.in
-setuptools==50.3.2
+setuptools==59.8.0
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -89,7 +89,7 @@ py==1.11.0
     #   -r requirements/dev.txt
     #   pytest
     #   tox
-pylint==2.14.3
+pylint==2.14.4
     # via
     #   -r requirements/dev.txt
     #   pylint-celery
@@ -148,18 +148,18 @@ tomlkit==0.11.0
     # via
     #   -r requirements/dev.txt
     #   pylint
-tox==3.25.0
+tox==3.25.1
     # via
     #   -r requirements/dev.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.txt
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/dev.txt
     #   astroid
     #   pylint
-virtualenv==20.15.0
+virtualenv==20.15.1
     # via
     #   -r requirements/dev.txt
     #   tox


### PR DESCRIPTION
### Description
- Ran `make upgrade` locally to update `pip` to latest available version and resolve the failure occurring with scheduled requirements upgrade task.