### PR TITLE
Pin tox to <4.0.0

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -25,3 +25,7 @@ setuptools<60
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
+
+# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
+# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
+tox<4.0.0


### PR DESCRIPTION
**Description:**

Tox >4.0.0 has breaking changes and is causing CI to fail in all upgrade PRs. Description of the issue has been attached in constraints file.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Documentation updated (not only docstrings) (if needed)
- [x] Commits are squashed
