### PR TITLE
fix: adding a pin for cryptography. latest version is throwing error.

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -30,7 +30,11 @@ django-simple-history==3.0.0
 # Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
 tox<4.0.0
 
-# edx-sphinx-theme is not compatible with latest Sphinx==6.0.0 version 
+# edx-sphinx-theme is not compatible with latest Sphinx==6.0.0 version
 # Pinning Sphinx version unless the compatibility issue gets resolved
 # For details, see issue https://github.com/openedx/edx-sphinx-theme/issues/197
 sphinx<6.0.0
+
+# cryptography==39.0.0 throwing AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'
+cryptography<39.0.0
+


### PR DESCRIPTION
https://github.com/pyca/cryptography/issues/7959
https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss
