### PR TITLE
fix: remove global setuptools constraint

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -19,10 +19,6 @@ Django<4.0
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
 
-# setuptools==60.0 had breaking changes and busted several service's pipeline.
-# Details can be found here: https://github.com/pypa/setuptools/issues/2940
-setuptools<60
-
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
 


### PR DESCRIPTION
### Description
- `setuptools` had been pinned due to an issue in the pipelines. Details are mentioned in the issue https://github.com/edx/edx-arch-experiments/issues/150. 
- PR https://github.com/openedx/edx-platform/pull/31647 in edx-platform removed the `setuptools` constraint manually and the deployment was successful so we can now remove the common constraint for all the repos.