### PR TITLE
fix: Be precise about the exception we're ignoring.

### DIFF
--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -509,4 +509,4 @@ int-import-graph=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/edx_lint/files/pylintrc
+++ b/edx_lint/files/pylintrc
@@ -508,5 +508,5 @@ int-import-graph=
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when being caught. Defaults to
-# "Exception"
+# "builtins.Exception"
 overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
We're currently getting the following in pylint output:

pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.
