### PR TITLE
docs: Remove repo specific CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,9 +1,0 @@
-How To Contribute
-=================
-
-Contributions are very welcome.
-
-Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
-
-Even though it was written with ``edx-platform`` in mind, the guidelines
-should be followed for Open edX code in general.


### PR DESCRIPTION
We now have a org wide CONTRIBUTING.md that points to our correct
general contributing guidelines.  We don't need repo specific ones that
forward to other contributing docs.
