### PR TITLE
fix: fix the make upgrade target to upgrade pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ requirements: ## install the developer requirements
 compile-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade
 compile-requirements: ## compile the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	# Make sure to compile files after any other files they include!
-	pip-compile -v --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile -v ${COMPILE_OPTS} --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile -v ${COMPILE_OPTS} -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
@@ -33,9 +33,9 @@ mccabe==0.7.0
     # via pylint
 pbr==5.11.1
     # via stevedore
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via pylint
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   -r requirements/base.in
     #   pylint-celery
@@ -61,7 +61,7 @@ text-unidecode==1.3
     # via python-slugify
 tomli==2.0.1
     # via pylint
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ filelock==3.12.0
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -56,7 +56,7 @@ pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -65,7 +65,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   -r requirements/base.txt
     #   pylint-celery
@@ -105,7 +105,7 @@ tomli==2.0.1
     #   -r requirements/base.txt
     #   pylint
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -121,7 +121,7 @@ typing-extensions==4.5.0
     #   -r requirements/base.txt
     #   astroid
     #   pylint
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via tox
 wrapt==1.15.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.37.1
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==59.8.0
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -22,7 +22,7 @@ code-annotations==1.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
-coverage==7.2.3
+coverage==7.2.5
     # via -r requirements/test.in
 dill==0.3.6
     # via
@@ -32,7 +32,7 @@ distlib==0.3.6
     # via
     #   -r requirements/dev.txt
     #   virtualenv
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/test.in
@@ -74,7 +74,7 @@ pbr==5.11.1
     # via
     #   -r requirements/dev.txt
     #   stevedore
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -88,7 +88,7 @@ py==1.11.0
     # via
     #   -r requirements/dev.txt
     #   tox
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   -r requirements/dev.txt
     #   pylint-celery
@@ -135,7 +135,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -151,7 +151,7 @@ typing-extensions==4.5.0
     #   -r requirements/dev.txt
     #   astroid
     #   pylint
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via
     #   -r requirements/dev.txt
     #   tox


### PR DESCRIPTION
**Description:**

Updated the Makefile `make upgrade` target to also upgrade `pip.txt` when the target is executed. 
It fixes the `pip` & `pip-tools` version conflict by upgrading `pip` since the latest `pip-tools>=6.13.0` requires `pip>=23.1.0` to work.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Commits are squashed
