### PR TITLE
chore: add constraint to edx-drf-extensions

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -15,6 +15,10 @@
 # using LTS django version
 Django<4.0
 
+# We are currently testing the latest (unreleased) changes with edx-platform. Adding constraint here as a 
+# preventive measure so even if the package is released by someone, it shouldn't be installed anywhere.
+edx-drf-extensions<=8.7.0 
+
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0


### PR DESCRIPTION
**Description:**

We are currently testing the latest (unreleased) changes with edx-platform. Adding constraint here as a preventive measure so that even if the package is released by someone, it shouldn't be installed anywhere.

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [x] Commits are squashed
