### PR TITLE
feat: Remove constraint on edx-drf-extensions<8.8.0

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -30,8 +30,3 @@ tox<4.0.0
 # Pinning Sphinx version unless the compatibility issue gets resolved
 # For details, see issue https://github.com/openedx/edx-sphinx-theme/issues/197
 sphinx<6.0.0
-
-# 2023-05-18: edx-drf-extensions 8.8.0 inadvertently introduced stricter Base64 decoding,
-# and some of our IDAs have malformed configs. This should be a very temporary constraint.
-# See https://github.com/openedx/edx-drf-extensions/issues/346 for details.
-edx-drf-extensions<8.8.0


### PR DESCRIPTION
Reverts openedx/edx-lint#342 -- we've fixed the base64 padding issues in 2U's configs.

See https://github.com/openedx/edx-drf-extensions/issues/346