### PR TITLE
fix: remove global tox constraint

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -21,7 +21,3 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
-
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0


### PR DESCRIPTION
**Description:**
- PR created under the issue https://github.com/openedx/edx-lint/issues/336 to remove the global tox constraint
- All the edx/openedx repositories have already been upgraded to remove the usage of tox-battery due to which the global constraint was being used. 