### PR TITLE
fix: add global platformdirs constraint

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -21,3 +21,8 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
+
+# virtualenv latest version requires platformdirs<4.0 which conflicts with tox>4.0 version
+# This constraint can be removed once the issue 
+# https://github.com/pypa/virtualenv/issues/2666 gets resolved 
+platformdirs<4.0


### PR DESCRIPTION
## Description
- With the removal of global constraint `tox<4.0`, now the tox requires `platformdirs==4.0` but virtualenv requires `platformdirs<4.0` which conflict and hence the requirements upgrade build fails for all repositories.
- Added the global constraint `platformdirs<4.0` to fix the failing requirements upgrade builds.
- This constraint can be removed once the new version of virtualenv is out and the issue https://github.com/pypa/virtualenv/issues/2666 is fixed. 
- Created followup issue https://github.com/openedx/edx-lint/issues/378 to remove this global constraint.