### PR TITLE
fix: remove platform dirs global constraint

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -21,8 +21,3 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
-
-# virtualenv latest version requires platformdirs<4.0 which conflicts with tox>4.0 version
-# This constraint can be removed once the issue 
-# https://github.com/pypa/virtualenv/issues/2666 gets resolved 
-platformdirs<4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,10 +31,8 @@ mccabe==0.7.0
     # via pylint
 pbr==6.0.0
     # via stevedore
-platformdirs==3.11.0
-    # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
-    #   pylint
+platformdirs==4.0.0
+    # via pylint
 pylint==3.0.2
     # via
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -20,9 +20,8 @@ packaging==23.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   tox
     #   virtualenv
 pluggy==1.3.0
@@ -33,7 +32,7 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.11.3
+tox==4.11.4
     # via -r requirements/ci.in
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,9 +54,8 @@ pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   pylint
     #   virtualenv
@@ -120,5 +119,5 @@ typing-extensions==4.8.0
     #   -r requirements/base.txt
     #   astroid
     #   pylint
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via build
 packaging==23.2
     # via build

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -70,9 +70,8 @@ pbr==6.0.0
     # via
     #   -r requirements/dev.txt
     #   stevedore
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via
-    #   -c requirements/../edx_lint/files/common_constraints.txt
     #   -r requirements/dev.txt
     #   pylint
     #   virtualenv
@@ -148,7 +147,7 @@ typing-extensions==4.8.0
     #   asgiref
     #   astroid
     #   pylint
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via
     #   -r requirements/dev.txt
     #   tox


### PR DESCRIPTION
## Description
- New version of `virtualenv` is out with `platformdirs v4` support so removing the global constraint since it is not needed anymore. 