### PR TITLE
chore: update Django constraint to match latest LTS version

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -13,7 +13,7 @@
 
 
 # using LTS django version
-Django<4.0
+Django<5.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html


### PR DESCRIPTION
**Description:**

This PR updates the Django common constraint used by other projects' repositories to use the latest LTS version: https://openedx.atlassian.net/wiki/spaces/AC/pages/3767926815/Django+4.2+Upgrade+Plan

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed) NA
- [ ] Documentation updated (not only docstrings) (if needed) NA
- [x] Commits are squashed
