### PR TITLE
feat: Pin importlib-metadata globally for opentelemetry

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -28,4 +28,5 @@ django-simple-history==3.0.0
 # adding the opentelemetry dependency. However, when we compile pip-tools.txt,
 # that uses version 7.x, and then there's no undoing that when compiling base.txt.
 # So we need to pin it globally, for now.
+# Ticket for unpinning: https://github.com/openedx/edx-lint/issues/407
 importlib-metadata<7

--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -21,3 +21,11 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
+
+# opentelemetry requires version 6.x at the moment:
+# https://github.com/open-telemetry/opentelemetry-python/issues/3570
+# Normally this could be added as a constraint in edx-django-utils, where we're
+# adding the opentelemetry dependency. However, when we compile pip-tools.txt,
+# that uses version 7.x, and then there's no undoing that when compiling base.txt.
+# So we need to pin it globally, for now.
+importlib-metadata<7


### PR DESCRIPTION
This will be needed for https://github.com/openedx/edx-django-utils/issues/389
