### PR TITLE
build: remove Arbi-BOM from tagging on upgrade PRs

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,8 +13,6 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "arbi-bom"
-       email_address: arbi-bom@edx.org  
        send_success_notification: false
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Arbi-BOM is no longer the maintainer of this repo.