### PR TITLE
fix: pin event-tracking for pymongo 4.4.0 support

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -31,3 +31,10 @@ django-simple-history==3.0.0
 # So we need to pin it globally, for now.
 # Ticket for unpinning: https://github.com/openedx/edx-lint/issues/407
 importlib-metadata<7
+
+# Cause: https://github.com/openedx/event-tracking/pull/290
+# event-tracking 2.4.1 upgrades to pymongo 4.4.0 which is not supported on edx-platform.
+# We will pin event-tracking to do not break existing installations
+# This can be unpinned once https://github.com/openedx/edx-platform/issues/34586
+# has been resolved and edx-platform is running with pymongo>=4.4.0
+event-tracking<2.4.1


### PR DESCRIPTION
**Description:**

Pins event-tracking to a version before installing pymongo 4.4.0 which is not supported on edx-platform.

See https://github.com/openedx/tutor-contrib-aspects/issues/891, https://github.com/openedx/event-routing-backends/pull/436, https://github.com/openedx/completion/pull/305 for more information.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [ ] Commits are squashed
