### PR TITLE
fix: upgrade pymongo and event-tracking

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -11,7 +11,6 @@
 # Note: Changes to this file will automatically be used by other repos, referencing
 #  this file from Github directly. It does not require packaging in edx-lint.
 
-
 # using LTS django version
 Django<5.0
 
@@ -22,13 +21,6 @@ elasticsearch<7.14.0
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
-
-# Cause: https://github.com/openedx/event-tracking/pull/290
-# event-tracking 2.4.1 upgrades to pymongo 4.4.0 which is not supported on edx-platform.
-# We will pin event-tracking to do not break existing installations
-# This can be unpinned once https://github.com/openedx/edx-platform/issues/34586
-# has been resolved and edx-platform is running with pymongo>=4.4.0
-event-tracking<2.4.1
 
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.


### PR DESCRIPTION
**Description:**

The constraint on event tracking is causing packages that depend on event-tracking (such as edx-search) to require pymongo==3.3.13, which is turn breaking other packages, such as openedx/forum. This requirement is no longer necessary since July 31st 2024 when this issue was closed: https://github.com/openedx/edx-platform/issues/34586
Edx-platform now runs pymongo=4.4.0: https://github.com/openedx/edx-platform/blob/master/requirements/edx/base.txt

**JIRA: (Optional)**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [ ] Commits are squashed
