### PR TITLE
feat: [FC-0074] add linter for Open edX Filters classes definitions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+5.6.0 - 2025-01-24
+~~~~~~~~~~~~~~~~~~
+
+* Add docstring linter for Open edX filters.
+
 5.5.0 - 2025-01-22
 ~~~~~~~~~~~~~~~~~~
 

--- a/edx_lint/__init__.py
+++ b/edx_lint/__init__.py
@@ -2,4 +2,4 @@
 edx_lint standardizes lint configuration and additional plugins for use in
 Open edX code.
 """
-__version__ = "5.5.0"
+__version__ = "5.6.0"

--- a/edx_lint/pylint/filters_docstring/__init__.py
+++ b/edx_lint/pylint/filters_docstring/__init__.py
@@ -1,0 +1,10 @@
+"""
+edx_lint filters_docstring module (optional plugin for filters docstrings).
+
+Add this to your pylintrc::
+    load-plugins=edx_lint.pylint.filters_docstring
+"""
+
+from .filters_docstring_check import register_checkers
+
+register = register_checkers

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -57,8 +57,17 @@ class FiltersDocstringFormatChecker(BaseChecker):
         DOCSTRING_MISSING_TRIGGER,
     )
     def visit_classdef(self, node):
-        """Visit a class definition and check its docstring."""
+        """
+        Visit a class definition and check its docstring.
+
+        If the class is a subclass of OpenEdxPublicFilter, check the format of its docstring. Skip the
+        OpenEdxPublicFilter class itself.
+
+        """
         if not node.is_subtype_of("openedx_filters.tooling.OpenEdxPublicFilter"):
+            return
+
+        if node.name == "OpenEdxPublicFilter":
             return
 
         docstring = node.doc_node.value if node.doc_node else ""

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -33,19 +33,19 @@ class FiltersDocstringFormatChecker(BaseChecker):
 
     msgs = {
         ("E%d90" % BASE_ID): (
-            "Filter's (%s) docstring is missing the required description section",
+            "Filter's (%s) docstring is missing the required description section or is badly formatted",
             DOCSTRING_MISSING_DESCRIPTION,
-            "filters docstring is missing the required description section",
+            "filters docstring is missing the required description section or is badly formatted",
         ),
         ("E%d91" % BASE_ID): (
-            "Filter's (%s) docstring is missing the required filter type section",
+            "Filter's (%s) docstring is missing the required filter type section or is badly formatted",
             DOCSTRING_MISSING_TYPE,
-            "filters docstring is missing the required filter type section",
+            "filters docstring is missing the required filter type section or is badly formatted",
         ),
         ("E%d92" % BASE_ID): (
-            "Filter's (%s) docstring is missing the required trigger section",
+            "Filter's (%s) docstring is missing the required trigger section or is badly formatted",
             DOCSTRING_MISSING_TRIGGER,
-            "filters docstring is missing the required trigger section",
+            "filters docstring is missing the required trigger section or is badly formatted",
         ),
     }
 

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -114,7 +114,7 @@ class FiltersDocstringFormatChecker(BaseChecker):
         """
         if not re.search(r"Purpose:\s*.*\n", docstring):
             return self.DOCSTRING_MISSING_PURPOSE_OR_BADLY_FORMATTED
-        return
+        return None
 
     def _check_filter_type_missing_or_incorrect(self, node, docstring):
         """
@@ -125,7 +125,7 @@ class FiltersDocstringFormatChecker(BaseChecker):
         filter_type = node.locals["filter_type"][0].statement().value.value
         if not re.search(r"Filter Type:\s*%s" % filter_type, docstring):
             return self.DOCSTRING_MISSING_OR_INCORRECT_TYPE
-        return
+        return None
 
     def _check_trigger_missing_or_badly_formatted(self, docstring):
         """
@@ -139,4 +139,4 @@ class FiltersDocstringFormatChecker(BaseChecker):
             re.MULTILINE,
         ):
             return self.DOCSTRING_MISSING_TRIGGER_OR_BADLY_FORMATTED
-        return
+        return None

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -8,9 +8,11 @@ A filter's docstring should have the following structure:
 3. Trigger: A line that starts with "Trigger:".
 """
 
-from pylint.checkers import BaseChecker, utils
 import re
-from ..common import BASE_ID
+
+from pylint.checkers import BaseChecker, utils
+
+from edx_lint.pylint.common import BASE_ID
 
 
 def register_checkers(linter):

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -122,7 +122,11 @@ class FiltersDocstringFormatChecker(BaseChecker):
 
         If the filter type is missing or incorrect, return the error message. Otherwise, return.
         """
-        filter_type = node.locals["filter_type"][0].statement().value.value
+        filter_type = node.locals.get("filter_type")
+        if not filter_type:
+            return self.DOCSTRING_MISSING_OR_INCORRECT_TYPE
+
+        filter_type = filter_type[0].statement().value.value if filter_type else ""
         if not re.search(r"Filter Type:\s*%s" % filter_type, docstring):
             return self.DOCSTRING_MISSING_OR_INCORRECT_TYPE
         return None

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -27,24 +27,24 @@ class FiltersDocstringFormatChecker(BaseChecker):
 
     name = "docstring-format-checker"
 
-    FILTER_DOCSTRING_MISSING_DESCRIPTION = "filter-docstring-missing-description"
-    FILTER_DOCSTRING_MISSING_TYPE = "filter-docstring-missing-type"
-    FILTER_DOCSTRING_MISSING_TRIGGER = "filter-docstring-missing-trigger"
+    DOCSTRING_MISSING_DESCRIPTION = "filter-docstring-missing-description"
+    DOCSTRING_MISSING_TYPE = "filter-docstring-missing-type"
+    DOCSTRING_MISSING_TRIGGER = "filter-docstring-missing-trigger"
 
     msgs = {
         ("E%d90" % BASE_ID): (
             "Filter's (%s) docstring is missing the required description section",
-            FILTER_DOCSTRING_MISSING_DESCRIPTION,
+            DOCSTRING_MISSING_DESCRIPTION,
             "filters docstring is missing the required description section",
         ),
         ("E%d91" % BASE_ID): (
             "Filter's (%s) docstring is missing the required filter type section",
-            FILTER_DOCSTRING_MISSING_TYPE,
+            DOCSTRING_MISSING_TYPE,
             "filters docstring is missing the required filter type section",
         ),
         ("E%d92" % BASE_ID): (
             "Filter's (%s) docstring is missing the required trigger section",
-            FILTER_DOCSTRING_MISSING_TRIGGER,
+            DOCSTRING_MISSING_TRIGGER,
             "filters docstring is missing the required trigger section",
         ),
     }
@@ -52,9 +52,9 @@ class FiltersDocstringFormatChecker(BaseChecker):
     options = ()
 
     @utils.only_required_for_messages(
-        FILTER_DOCSTRING_MISSING_DESCRIPTION,
-        FILTER_DOCSTRING_MISSING_TYPE,
-        FILTER_DOCSTRING_MISSING_TRIGGER,
+        DOCSTRING_MISSING_DESCRIPTION,
+        DOCSTRING_MISSING_TYPE,
+        DOCSTRING_MISSING_TRIGGER,
     )
     def visit_classdef(self, node):
         """Visit a class definition and check its docstring."""
@@ -94,11 +94,11 @@ class FiltersDocstringFormatChecker(BaseChecker):
         ```
         """
         required_sections = [
-            (r"Description:\s*.*\n", self.FILTER_DOCSTRING_MISSING_DESCRIPTION),
-            (r"Filter Type:\s*.*\n", self.FILTER_DOCSTRING_MISSING_TYPE),
+            (r"Description:\s*.*\n", self.DOCSTRING_MISSING_DESCRIPTION),
+            (r"Filter Type:\s*.*\n", self.DOCSTRING_MISSING_TYPE),
             (
                 r"Trigger:\s*(NA|-\s*Repository:\s*[^\n]+\s*-\s*Path:\s*[^\n]+\s*-\s*Function\s*or\s*Method:\s*[^\n]+)",
-                self.FILTER_DOCSTRING_MISSING_TRIGGER,
+                self.DOCSTRING_MISSING_TRIGGER,
             ),
         ]
         error_messages = []

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -62,10 +62,7 @@ class FiltersDocstringFormatChecker(BaseChecker):
         OpenEdxPublicFilter class itself.
 
         """
-        if not node.is_subtype_of("openedx_filters.tooling.OpenEdxPublicFilter"):
-            return
-
-        if node.name == "OpenEdxPublicFilter":
+        if not node.is_subtype_of("openedx_filters.tooling.OpenEdxPublicFilter") or node.name == "OpenEdxPublicFilter":
             return
 
         docstring = node.doc_node.value if node.doc_node else ""

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -27,22 +27,22 @@ class FiltersDocstringFormatChecker(BaseChecker):
 
     name = "docstring-format-checker"
 
-    DOCSTRING_MISSING_DESCRIPTION = "filter-docstring-missing-description"
+    DOCSTRING_MISSING_PURPOSE = "filter-docstring-missing-purpose"
     DOCSTRING_MISSING_TYPE = "filter-docstring-missing-type"
     DOCSTRING_MISSING_TRIGGER = "filter-docstring-missing-trigger"
 
     msgs = {
-        ("E%d90" % BASE_ID): (
-            "Filter's (%s) docstring is missing the required description section or is badly formatted",
-            DOCSTRING_MISSING_DESCRIPTION,
-            "filters docstring is missing the required description section or is badly formatted",
-        ),
         ("E%d91" % BASE_ID): (
-            "Filter's (%s) docstring is missing the required filter type section or is badly formatted",
-            DOCSTRING_MISSING_TYPE,
-            "filters docstring is missing the required filter type section or is badly formatted",
+            "Filter's (%s) docstring is missing the required purpose section or is badly formatted",
+            DOCSTRING_MISSING_PURPOSE,
+            "filters docstring is missing the required purpose section or is badly formatted",
         ),
         ("E%d92" % BASE_ID): (
+            "Filter's (%s) docstring is missing the required type section or is badly formatted",
+            DOCSTRING_MISSING_TYPE,
+            "filters docstring is missing the required type section or is badly formatted",
+        ),
+        ("E%d93" % BASE_ID): (
             "Filter's (%s) docstring is missing the required trigger section or is badly formatted",
             DOCSTRING_MISSING_TRIGGER,
             "filters docstring is missing the required trigger section or is badly formatted",
@@ -52,7 +52,7 @@ class FiltersDocstringFormatChecker(BaseChecker):
     options = ()
 
     @utils.only_required_for_messages(
-        DOCSTRING_MISSING_DESCRIPTION,
+        DOCSTRING_MISSING_PURPOSE,
         DOCSTRING_MISSING_TYPE,
         DOCSTRING_MISSING_TRIGGER,
     )
@@ -103,7 +103,7 @@ class FiltersDocstringFormatChecker(BaseChecker):
         ```
         """
         required_sections = [
-            (r"Description:\s*.*\n", self.DOCSTRING_MISSING_DESCRIPTION),
+            (r"Purpose:\s*.*\n", self.DOCSTRING_MISSING_PURPOSE),
             (r"Filter Type:\s*.*\n", self.DOCSTRING_MISSING_TYPE),
             (
                 r"Trigger:\s*(NA|-\s*Repository:\s*[^\n]+\s*-\s*Path:\s*[^\n]+\s*-\s*Function\s*or\s*Method:\s*[^\n]+)",

--- a/edx_lint/pylint/filters_docstring/filters_docstring_check.py
+++ b/edx_lint/pylint/filters_docstring/filters_docstring_check.py
@@ -1,0 +1,106 @@
+"""
+Pylint checker for the format of the docstrings of filters.
+
+A filter's docstring should have the following structure:
+
+1. Description: Any non-empty text followed by a blank line.
+2. Filter Type: A line that starts with "Filter Type:".
+3. Trigger: A line that starts with "Trigger:".
+"""
+
+from pylint.checkers import BaseChecker, utils
+import re
+from ..common import BASE_ID
+
+
+def register_checkers(linter):
+    """
+    Register checkers.
+    """
+    linter.register_checker(FiltersDocstringFormatChecker(linter))
+
+
+class FiltersDocstringFormatChecker(BaseChecker):
+    """Pylint checker for the format of the docstrings of filters."""
+
+    name = "docstring-format-checker"
+
+    FILTER_DOCSTRING_MISSING_DESCRIPTION = "filter-docstring-missing-description"
+    FILTER_DOCSTRING_MISSING_TYPE = "filter-docstring-missing-type"
+    FILTER_DOCSTRING_MISSING_TRIGGER = "filter-docstring-missing-trigger"
+
+    msgs = {
+        ("E%d90" % BASE_ID): (
+            "Filter's (%s) docstring is missing the required description section",
+            FILTER_DOCSTRING_MISSING_DESCRIPTION,
+            "filters docstring is missing the required description section",
+        ),
+        ("E%d91" % BASE_ID): (
+            "Filter's (%s) docstring is missing the required filter type section",
+            FILTER_DOCSTRING_MISSING_TYPE,
+            "filters docstring is missing the required filter type section",
+        ),
+        ("E%d92" % BASE_ID): (
+            "Filter's (%s) docstring is missing the required trigger section",
+            FILTER_DOCSTRING_MISSING_TRIGGER,
+            "filters docstring is missing the required trigger section",
+        ),
+    }
+
+    options = ()
+
+    @utils.only_required_for_messages(
+        FILTER_DOCSTRING_MISSING_DESCRIPTION,
+        FILTER_DOCSTRING_MISSING_TYPE,
+        FILTER_DOCSTRING_MISSING_TRIGGER,
+    )
+    def visit_classdef(self, node):
+        """Visit a class definition and check its docstring."""
+        if not node.is_subtype_of("openedx_filters.tooling.OpenEdxPublicFilter"):
+            return
+
+        docstring = node.doc_node.value if node.doc_node else ""
+        if not (error_messages := self._check_docstring_format(docstring)):
+            return
+        for error_message in error_messages:
+            self.add_message(error_message, node=node, args=(node.name,))
+
+    def _check_docstring_format(self, docstring):
+        """
+        Check the format of the docstring for errors and return a list of error messages.
+
+        The docstring should have the following structure:
+        1. Description: Any non-empty text followed by a blank line.
+        2. Filter Type: A line that starts with "Filter Type:".
+        3. Trigger: A line that starts with "Trigger:".
+
+        For example:
+
+        ```
+        Description:
+        Filter used to modify the certificate rendering process.
+
+        ... (more description)
+
+        Filter Type:
+            org.openedx.learning.certificate.render.started.v1
+
+        Trigger:
+            - Repository: openedx/edx-platform
+            - Path: lms/djangoapps/certificates/views/webview.py
+            - Function or Method: render_html_view
+        ```
+        """
+        required_sections = [
+            (r"Description:\s*.*\n", self.FILTER_DOCSTRING_MISSING_DESCRIPTION),
+            (r"Filter Type:\s*.*\n", self.FILTER_DOCSTRING_MISSING_TYPE),
+            (
+                r"Trigger:\s*(NA|-\s*Repository:\s*[^\n]+\s*-\s*Path:\s*[^\n]+\s*-\s*Function\s*or\s*Method:\s*[^\n]+)",
+                self.FILTER_DOCSTRING_MISSING_TRIGGER,
+            ),
+        ]
+        error_messages = []
+        for pattern, error_message in required_sections:
+            if not re.search(pattern, docstring, re.MULTILINE):
+                error_messages.append(error_message)
+        return error_messages


### PR DESCRIPTION
**Description:**

This PR adds a custom linter for Open edX Filter classes docstrings to check whether new filters follow the specified format: 

```
        Description:
        Filter used to modify the certificate rendering process.
        ... (more description)
        Filter Type:
            org.openedx.learning.certificate.render.started.v1
        Trigger:
            - Repository: openedx/edx-platform
            - Path: lms/djangoapps/certificates/views/webview.py
            - Function or Method: render_html_view
```

If a class is missing at least one of the section, then a pylint error is raised:

![image](https://github.com/user-attachments/assets/cb1dd076-ede0-44b3-889d-5fa3208aded2)

You can see the linter integrated into the repo in this PR: https://github.com/openedx/openedx-filters/pull/249

I'm open to moving this directly into the openedx-filters repo if needed, considering that the linter is kind of specific to that repository.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [ ] Commits are squashed
