### PR TITLE
fix: update commitlint config to use mjs syntax

### DIFF
--- a/edx_lint/files/commitlint.config.js
+++ b/edx_lint/files/commitlint.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+const Configuration = {
   extends: ['@commitlint/config-conventional'],
 
   helpUrl: 'https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html',
@@ -29,3 +29,5 @@ module.exports = {
     // https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/is-ignored/src/defaults.ts
   ],
 };
+
+export default Configuration;


### PR DESCRIPTION
**Description:**

This moves `commitlint.config.js` from CJS syntax to MJS syntax. This is one part of the fix for https://github.com/openedx/.github/issues/163.  I have verified this works with the commitlint workflow in https://github.com/openedx/paragon/pull/3435.


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [ ] Commits are squashed
