### PR TITLE
fix: increase commitlint header-max-length for squashed PR numbers

### DIFF
--- a/edx_lint/files/commitlint.config.js
+++ b/edx_lint/files/commitlint.config.js
@@ -9,6 +9,9 @@ const Configuration = {
         'revert', 'feat', 'fix', 'perf', 'docs', 'test', 'build', 'refactor', 'style', 'chore', 'temp',
       ]],
 
+    // Increase the header max length to account for PR numbers on squash merges
+    'header-max-length': [2, 'always', 110], 
+
     // Default rules we want to suppress:
     'body-leading-blank': [0, "always"],
     'body-max-line-length': [0, "always"],


### PR DESCRIPTION
**Description:**

The default `commitlint` `header-max-length` (from `config-conventional`) is 100 characters. This is generally not a problem, but in situations where a PR is squashed the default GH web UI behavior appends ` (#X[...]X)` to the commit message header. This can cause commits that have landed to fail `commitlint`.

This PR just gives us a little wiggle room for those scenarios. 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] If adding new checks, followed how_tos/0001-adding-new-checks.rst
- [ ] Changelog record added (if needed)
- [ ] Documentation updated (not only docstrings) (if needed)
- [ ] Commits are squashed
