### PR TITLE
docs: Update edx.rtd links to docs.openedx.org

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -118,7 +118,7 @@ Unreleased
 ~~~~~~~~~~~~~~~~~~~~
 
 * BREAKING CHANGE: Add linter for invalid imports from Django Waffle (`import waffle` and `from waffle import ...`). Instead, developers should import toggle objects from `edx_toggles.toggles`.
-* BREAKING CHANGE: Add linter for missing feature toggle annotations ("toggle-missing-annotation"). Check `this howto <https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html>`__ for more information on writing toggle annotations.
+* BREAKING CHANGE: Add linter for missing feature toggle annotations ("toggle-missing-annotation"). Check `this howto <https://docs.openedx.org/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html>`__ for more information on writing toggle annotations.
 * Fix duplicate annotation errors.
 
 [4.1.1] - 2021-03-16


### PR DESCRIPTION
edx-toggles was moved to docs.openedx.org, so update the references.