### PR TITLE
Remove some old common constraints

### DIFF
--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -25,7 +25,3 @@ django-simple-history==3.0.0
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0

--- a/edx_lint/files/common_constraints.txt
+++ b/edx_lint/files/common_constraints.txt
@@ -19,9 +19,6 @@ Django<5.0
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-django-simple-history==3.0.0
-
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3


### PR DESCRIPTION
- fix: Don't pin django-simple-history

    We removed this pin in edx-platform a while ago and if we can run these
    migrations there, I think any other services should be able to handle
    this as well.  Also there is no ticket with details here and so it is
    not clear if there was a specific concern other than performance issues
    with adding indexes.

    Reference (default branch in edx-platform as of today):
    https://github.com/openedx/edx-platform/blob/d29171c04649f29a26bfc96aa73b64bf01bfdd5b/Makefile#L124-L125

- fix: Drop the urllib3 constraint

    Other updates seem to have resolved the issue reported when this was
    pinned.  The issue there seems to be resolved in edx-platform now as
    shown in https://github.com/openedx/edx-platform/pull/37059

    Given that this was the only known issue with this, we can unpin this
    library.

Resolves https://github.com/openedx/edx-lint/issues/475
Resolves https://github.com/openedx/edx-lint/issues/476
